### PR TITLE
Windows: update to GSL 2.7 + ucrt support

### DIFF
--- a/src/Makevars.ucrt
+++ b/src/Makevars.ucrt
@@ -1,0 +1,3 @@
+CRT=-ucrt
+include Makevars.win
+OBJECTS = $(SOURCES:.c=.o)

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -3,14 +3,14 @@
 # CXXFLAGS in ~/.R/Makevars
 # This is from https://github.com/eddelbuettel/rcppgsl/blob/master/tools/winlibs.R
 RSCRIPT := "${R_HOME}/bin${R_ARCH_BIN}/Rscript.exe"
-GSL_ROOT :=$(shell $(RSCRIPT) -e 'cat(file.path(getwd(), "../windows/gsl-2.4/"))')
+GSL_ROOT :=$(shell $(RSCRIPT) -e 'cat(file.path(getwd(), "../windows/gsl-2.7/"))')
 GSL_CFLAGS = -I"$(GSL_ROOT)/include"
-GSL_LIBS   = -L"$(GSL_ROOT)/lib${R_ARCH}" -lgsl -lgslcblas
+GSL_LIBS   = -L"$(GSL_ROOT)/lib${R_ARCH}${CRT}" -lgsl -lgslcblas
 PKG_CPPFLAGS = $(GSL_CFLAGS) -DR_PACKAGE -DDEBUG=1 -I./eaf/ -I./mo-tools/
 PKG_LIBS = $(GSL_LIBS)
 EAF_SRC_FILES= avl.c eaf3d.c eaf.c io.c
 MOTOOLS_SRC_FILES = hv_contrib.c hv.c pareto.c whv.c whv_hype.c
-SOURCES = $(EAF_SRC_FILES:%=eaf/%) $(MOTOOLS_SRC_FILES:%=mo-tools/%) init.c  Reaf.c  Repsilon.c  Rhv.c  Rnondominated.c  
+SOURCES = $(EAF_SRC_FILES:%=eaf/%) $(MOTOOLS_SRC_FILES:%=mo-tools/%) init.c  Reaf.c  Repsilon.c  Rhv.c  Rnondominated.c
 OBJECTS = $(SOURCES:.c=.o)
 
 EXEEXT=.exe
@@ -30,7 +30,7 @@ all: $(SHLIB)
 	$(MAKE) -C eaf all march=none CC="$(CC)" CFLAGS="$(CFLAGS)" OPT_CFLAGS="" WARN_CFLAGS="" DEBUG=0 EXE=$(EXEEXT)
 	$(MAKE) -C mo-tools all march=none CC="$(CC)" CFLAGS="$(CFLAGS)" OPT_CFLAGS="" WARN_CFLAGS="" DEBUG=0 EXE=$(EXEEXT)
 
-$(SHLIB): $(OBJECTS) 
+$(SHLIB): $(OBJECTS)
 
 mo-tools/hv.o: PKG_CPPFLAGS += -DVARIANT=4
 
@@ -38,7 +38,7 @@ clean:
 	@-rm -f *.o *.so *.dll \
 	eaf/*.o $(eaf) \
 	$(igd) $(epsilon) $(dominatedsets) $(nondominated) $(ndsort) \
-	mo-tools/*.o 
+	mo-tools/*.o
 
 $(OBJECTS): winlibs
 

--- a/tools/winlibs.R
+++ b/tools/winlibs.R
@@ -1,9 +1,9 @@
-# Download GSL 2.4 Rtools build
-if(!file.exists("../windows/gsl-2.4/include/gsl/gsl_blas.h")){
-  download.file("https://github.com/rwinlib/gsl/archive/v2.4.zip", "lib.zip", quiet = TRUE)
+# Download GSL 2.7 Rtools build
+if(!file.exists("../windows/gsl-2.7/include/gsl/gsl_blas.h")){
+  download.file("https://github.com/rwinlib/gsl/archive/v2.7.zip", "lib.zip", quiet = TRUE)
   dir.create("../windows", showWarnings = FALSE)
   unzip("lib.zip", exdir = "../windows")
   unlink("lib.zip")
-  stopifnot(file.exists("../windows/gsl-2.4/include/gsl/gsl_errno.h"))
+  stopifnot(file.exists("../windows/gsl-2.7/include/gsl/gsl_errno.h"))
   cat("Downloaded to '", file.path(getwd(), "../windows"), "'\n")
 }


### PR DESCRIPTION
Hello @MLopez-Ibanez ! This will update to libgsl 2.7 on Windows, which also adds support for the upcoming UCRT based toolchains.

I have tested this for you with the current and future Windows toolchains. 