### PR TITLE
Use gsl from Rtools >= 42 on Windows.

### DIFF
--- a/src/Makevars.ucrt
+++ b/src/Makevars.ucrt
@@ -1,3 +1,30 @@
-CRT=-ucrt
-include Makevars.win
+# 							-*- mode: makefile -*-
+# Do not put GCC specific flags here. Put them instead in CFLAGS and
+# CXXFLAGS in ~/.R/Makevars
+#GSL_CFLAGS = -I"$(GSL_ROOT)/include"
+#GSL_LIBS   = -L"$(GSL_ROOT)/lib${R_ARCH}${CRT}" -lgsl -lgslcblas
+ifeq (,$(shell pkg-config --version 2>/dev/null))
+  GSL_LIBS = -lgsl -lgslcblas -lm
+else
+  GSL_CFLAGS = $(shell pkg-config --cflags gsl)
+  GSL_LIBS = $(shell pkg-config --libs gsl)
+endif
+
+DEBUG=0
+PKG_CPPFLAGS = $(GSL_CFLAGS) -DR_PACKAGE -DDEBUG=$(DEBUG) -I./eaf/ -I./mo-tools/
+PKG_LIBS = $(GSL_LIBS)
+EAF_SRC_FILES= avl.c eaf3d.c eaf.c io.c
+MOTOOLS_SRC_FILES = hv_contrib.c hv.c pareto.c whv.c whv_hype.c
+SOURCES = $(EAF_SRC_FILES:%=eaf/%) $(MOTOOLS_SRC_FILES:%=mo-tools/%) init.c  Reaf.c  Repsilon.c  Rhv.c  Rnondominated.c
 OBJECTS = $(SOURCES:.c=.o)
+
+export GSL_CFLAGS GSL_LIBS
+
+.PHONY: all clean
+
+all: $(SHLIB)
+
+$(SHLIB): $(OBJECTS)
+
+clean:
+	@-rm -f *.o *.so *.dll eaf/*.o	mo-tools/*.o


### PR DESCRIPTION
This patch switches to using gsl from the system, when available via pkg-config or otherwise using hard-coded library dependencies. It makes the package work with gsl from Rtools42-45. Behavior with previous versions of R is not affected, as this uses the `.ucrt` version of Makevars.

Using libraries from the system/Rtools when available is required by the CRAN repository policy. Also, it silences a warning (now on CRAN results) about using non-allowed external symbols.